### PR TITLE
update to velocity 3.3.0-SNAPSHOT

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: temurin
-        java-version: 11
+        java-version: 17
     - name: Cache Gradle
       uses: actions/cache@v3
       with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ junitVersion=5.9.2
 nettyVersion=4.1.89.Final
 rxjavaVersion=3.1.6
 slf4jVersion=1.7.36
-velocityVersion=3.1.1
+velocityVersion=3.3.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ junitVersion=5.9.2
 nettyVersion=4.1.89.Final
 rxjavaVersion=3.1.6
 slf4jVersion=1.7.36
-velocityVersion=3.3.0-SNAPSHOT
+velocityVersion=3.3.0-20240907.171610-130

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -34,8 +34,8 @@ jar {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 shadowJar {

--- a/velocity/src/main/java/io/github/lxgaming/location/velocity/network/netty/PacketHandlerImpl.java
+++ b/velocity/src/main/java/io/github/lxgaming/location/velocity/network/netty/PacketHandlerImpl.java
@@ -19,8 +19,8 @@ package io.github.lxgaming.location.velocity.network.netty;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.proxy.connection.registry.DimensionInfo;
 import com.velocitypowered.proxy.protocol.ProtocolUtils;
-import com.velocitypowered.proxy.protocol.packet.JoinGame;
-import com.velocitypowered.proxy.protocol.packet.Respawn;
+import com.velocitypowered.proxy.protocol.packet.JoinGamePacket;
+import com.velocitypowered.proxy.protocol.packet.RespawnPacket;
 import io.github.lxgaming.location.common.entity.DimensionImpl;
 import io.github.lxgaming.location.common.entity.UserImpl;
 import io.github.lxgaming.location.common.network.netty.PacketHandler;
@@ -37,9 +37,7 @@ public class PacketHandlerImpl extends PacketHandler {
 
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        if (msg instanceof JoinGame) {
-            JoinGame packet = (JoinGame) msg;
-
+        if (msg instanceof JoinGamePacket packet) {
             String dimensionName;
             if (packet.getDimensionInfo() != null) {
                 dimensionName = packet.getDimensionInfo().getRegistryIdentifier();
@@ -55,7 +53,7 @@ public class PacketHandlerImpl extends PacketHandler {
 
     @Override
     public void handleServerRespawn(ByteBuf byteBuf) {
-        Respawn packet = new Respawn();
+        RespawnPacket packet = new RespawnPacket();
         packet.decode(byteBuf, ProtocolUtils.Direction.CLIENTBOUND, ProtocolVersion.getProtocolVersion(getProtocolVersion()));
 
         DimensionInfo dimensionInfo = VelocityToolbox.getDimensionInfo(packet);

--- a/velocity/src/main/java/io/github/lxgaming/location/velocity/util/VelocityToolbox.java
+++ b/velocity/src/main/java/io/github/lxgaming/location/velocity/util/VelocityToolbox.java
@@ -19,7 +19,7 @@ package io.github.lxgaming.location.velocity.util;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.registry.DimensionInfo;
 import com.velocitypowered.proxy.network.Connections;
-import com.velocitypowered.proxy.protocol.packet.Respawn;
+import com.velocitypowered.proxy.protocol.packet.RespawnPacket;
 import io.github.lxgaming.location.common.entity.UserImpl;
 import io.github.lxgaming.location.common.network.netty.PacketHandler;
 import io.github.lxgaming.location.common.util.Toolbox;
@@ -39,7 +39,7 @@ public class VelocityToolbox {
         MethodHandle dimensionInfoMethodHandleTemporary;
 
         try {
-            Field field = Respawn.class.getDeclaredField("dimensionInfo");
+            Field field = RespawnPacket.class.getDeclaredField("dimensionInfo");
             field.setAccessible(true);
 
             dimensionInfoMethodHandleTemporary = lookup.unreflectGetter(field);
@@ -70,7 +70,7 @@ public class VelocityToolbox {
         return false;
     }
 
-    public static DimensionInfo getDimensionInfo(Respawn respawn) {
+    public static DimensionInfo getDimensionInfo(RespawnPacket respawn) {
         try {
             if (dimensionInfoMethodHandle == null) {
                 return null;


### PR DESCRIPTION
Updates Location to the latest version of Velocity
Velocity 3.3.0-SNAPSHOT modified the packet class names which result in a `ClassNotFoundException` at runtime.

Changes:
- bump java version in ci workflow to 17
- bump velocity minimum jvm version to 17
- bump velocity api to 3.3.0-SNAPSHOT (pinned to 3.3.0-20240907.171610-130, the API should be stable enough)
- replace velocity jar with current 3.3.0-SNAPSHOT build (Build no. 430)
- update packet class names